### PR TITLE
Applied "Con fix" to env_lm_no_lm & env_lm_nm

### DIFF
--- a/package/manifest.json
+++ b/package/manifest.json
@@ -2,9 +2,10 @@
     "manifestVersion": "1.1.0",
     "files": {},
     "label": "censhine",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "category": "fix",
     "author": "Sledmine, Jerry",
+    "colabs": "Mata",
     "name": "CEnshine",
     "description": "Shaders enhancement for Halo Custom Edition"
 }

--- a/src/game/rasterizer/dx9/shaders/pixel/environment_lightmap/environment_lightmap_no_illumination.fx
+++ b/src/game/rasterizer/dx9/shaders/pixel/environment_lightmap/environment_lightmap_no_illumination.fx
@@ -40,15 +40,18 @@ half4 main(PS_INPUT i) : SV_TARGET
 	////////////////////////////////////////////////////////////
 	// calculate bump attenuation
 	////////////////////////////////////////////////////////////
+	half baked_attenuation = dot(normalize(2*normal_color.rgb-1), half3(0.0f, 0.0f, 1.0f));
 	half bump_attenuation = dot((2*bump_color.rgb)-1, (2*normal_color.rgb)-1);
-	bump_attenuation = (bump_attenuation * Diff.a) + 1-Diff.a;
+	bump_attenuation = 1 + bump_attenuation - baked_attenuation;
+	bump_attenuation = lerp(1, bump_attenuation, Diff.a);
 
 	////////////////////////////////////////////////////////////
 	// combine output
 	////////////////////////////////////////////////////////////
 	half3 final_color = lightmap_color;
-	final_color *= c_material_color;
 	final_color *= bump_attenuation;
+	final_color *= c_material_color;
+
 	
 	return TestAlphaGreaterRef( half4( final_color, bump_color.a), c_alpha_ref );
 };

--- a/src/game/rasterizer/dx9/shaders/pixel/environment_lightmap/environment_lightmap_normal.fx
+++ b/src/game/rasterizer/dx9/shaders/pixel/environment_lightmap/environment_lightmap_normal.fx
@@ -76,6 +76,7 @@ half4 main(PS_INPUT i) : SV_TARGET
 	// calculate bump attenuation
 	////////////////////////////////////////////////////////////
    float bump_attenuation = saturate(dot(normalize(2*bump_color.rgb-1), normalize(2*normal_color.rgb-1)));
+   float baked_attenuation = dot(normalize(2*normal_color.rgb-1), float3(0.0f, 0.0f, 1.0f));
    float bump_attenuation_with_accuracy = lerp(1, bump_attenuation, Diff.a);
    
 	////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi, I modified the shaders  to apply the fix discovered by Con and shared publicly on Reclaimers Discord (the credit for these fixes goes to him). The change adresses the legacy bumpmapping attenuation artifacts that the Xbox had back in the day, restoring some of the original Gearbox color brightness quality, without losing the classic normal map input on shading. I have the feeling this will become part of the official fixes so, yeah, hope it helps to bring better look for maps on Gearbox port.
Peace.