### PR TITLE
Get shader_model working

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,11 +28,11 @@ $SHADER_COMPILE_CMD/transparent_plasma/transparent_plasma.fx
 
 # Models
 $SHADER_COMPILE_CMD/model/model_environment.fx
-#$SHADER_COMPILE_CMD/model/model_mask_change_color.fx
-#$SHADER_COMPILE_CMD/model/model_mask_multipurpose.fx
-#$SHADER_COMPILE_CMD/model/model_mask_none.fx
-#$SHADER_COMPILE_CMD/model/model_mask_reflection.fx
-#$SHADER_COMPILE_CMD/model/model_mask_self_illumination.fx
+$SHADER_COMPILE_CMD/model/model_mask_change_color.fx
+$SHADER_COMPILE_CMD/model/model_mask_multipurpose.fx
+$SHADER_COMPILE_CMD/model/model_mask_none.fx
+$SHADER_COMPILE_CMD/model/model_mask_reflection.fx
+$SHADER_COMPILE_CMD/model/model_mask_self_illumination.fx
 
 # Environment fog
 $SHADER_COMPILE_CMD/environment/environment_fog.fx


### PR DESCRIPTION
This fixes the transparency issue from the old shader_model test build. Detail after reflection is the right way around so the chimera hack can be binned.